### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/config.json
+++ b/config.json
@@ -3,7 +3,7 @@
   "type": "app",
   "version": "2.0.0",
   "description": "Class-angnostic object detection model",
-  "docker_image": "supervisely/base-py-sdk:6.73.564",
+  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
   "categories": [
     "neural network",
     "object detection",

--- a/config.json
+++ b/config.json
@@ -31,5 +31,5 @@
     "name": "init"
   },
   "slug": "supervisely-ecosystem/owl-vit-app",
-  "min_instance_version": "6.15.35"
+  "instance_version": "6.15.60"
 }

--- a/config.json
+++ b/config.json
@@ -3,7 +3,7 @@
   "type": "app",
   "version": "2.0.0",
   "description": "Class-angnostic object detection model",
-  "docker_image": "supervisely/base-py-sdk:6.73.486",
+  "docker_image": "supervisely/base-py-sdk:6.73.564",
   "categories": [
     "neural network",
     "object detection",

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,1 +1,1 @@
-supervisely==6.73.486
+supervisely==6.73.564


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Does not release applications.

Validation: generated ecosystem inventory report.
